### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Awesome HTML5 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d2
 
 A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://github.com/ziadoz/awesome-php) and [awesome-python](https://github.com/vinta/awesome-python)
 
-##Table of Contents
+## Table of Contents
 - [Articles and standards](#articles-and-standards)
 - [Elements](#elements)
   - [Canvas](#canvas)
@@ -53,27 +53,27 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
   - [Twitter](#twitter)
 - [Contributing](#contributing)
 
-##Articles and standards
+## Articles and standards
 
 * [THML 5.2 Editor's Draft](http://w3c.github.io/html/)
 * [The extensible web manifesto](https://extensiblewebmanifesto.org/)
 * [Differences bewtween HTML5 and HTML4 from W3C](http://www.w3.org/TR/html5-diff/)
 * [DOCTYPES and markup styles from WPF](http://docs.webplatform.org/wiki/guides/doctypes_and_markup_styles)
 
-##Elements
+## Elements
 
-###Canvas
+### Canvas
 
 * [Brief description from W3 Schools](http://www.w3schools.com/tags/tag_canvas.asp)
 * [Tutorial from MDN](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial)
 * [Various Tutorials](http://www.html5canvastutorials.com/)
 * [Cheat Sheet](http://cheatsheetworld.com/programming/html5-canvas-cheat-sheet/)
 
-###Sectioning
+### Sectioning
 
 * [How to Use The HTML5 Sectioning Elements](http://blog.teamtreehouse.com/use-html5-sectioning-elements)
 
-###Media Elements
+### Media Elements
 
 * Audio and Video
   - [audio tag from W3Schools](http://www.w3schools.com/tags/tag_audio.asp)
@@ -87,97 +87,97 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * track tag
   - [Brief description from W3 Schools](http://www.w3schools.com/tags/tag_track.asp)
 
-###Forms
+### Forms
 
 * [Changes to forms in HTML5 from MDN](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Forms_in_HTML)
 
-###Details
+### Details
 
 * [How to Use the Details and Summary Elements](http://blog.teamtreehouse.com/use-details-summary-elements)
 * [Details element polyfill](https://www.smashingmagazine.com/2014/11/complete-polyfill-html5-details-element/)
 
-###Time
+### Time
 
 * [Time element guide](https://www.sitepoint.com/html5-time-element-guide/)
 
-###WebVTT
+### WebVTT
 
 * [First draft from W3C](http://www.w3.org/TR/2014/WD-webvtt1-20141113/)
 
-###HTML Imports
+### HTML Imports
 
 * [Introduction to HTML imports](http://webcomponents.org/articles/introduction-to-html-imports/)
 
-##APIs
+## APIs
 
-###Permissions
+### Permissions
 
 * [Permissions API for the Web by Google](https://developers.google.com/web/updates/2015/04/permissions-api-for-the-web)
 
-###Speech Synthesis
+### Speech Synthesis
 
 * [Intro to the HTML5 Speech Synthesis API](http://creative-punch.net/2014/10/intro-html5-speech-synthesis-api/)
 * [Another useful intro](https://shapeshed.com/html5-speech-recognition-api/)
 * [Experimenting with the Web Speech API](https://www.sitepoint.com/experimenting-web-speech-api/)
 * [Free voice recognition library (annyang)](https://www.talater.com/annyang/)
 
-###Geolocation
+### Geolocation
 
 * [Using Geolocation](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation)
 * [HTML5 Apps: Positioning with Geolocation](https://code.tutsplus.com/tutorials/html5-apps-positioning-with-geolocation--mobile-456)
 
-###Audio
+### Audio
 
 * [Getting started with the Web Audio API](http://www.html5rocks.com/en/tutorials/webaudio/intro/?redirect_from_locale=es)
 * [Web Audio API at MDN](https://developer.mozilla.org/es/docs/Web_Audio_API)
 * [Making a Guitar Tuner with HTML5](http://jonathan.bergknoff.com/journal/making-a-guitar-tuner-html5)
 
-###Cryptography
+### Cryptography
 
 * [Web Cryptography API draft](http://www.w3.org/TR/WebCryptoAPI/)
 * [Table of web cryptography support](http://diafygi.github.io/webcrypto-examples/)
 * [Window.crypto](https://developer.mozilla.org/en-US/docs/Web/API/Window/crypto)
 * [Cryptography next steps from W3C](http://www.w3.org/2012/webcrypto/webcrypto-next-workshop/report.html)
 
-###Media Capture
+### Media Capture
 
 * [Capturing Audio & Video in HTML5](http://www.html5rocks.com/es/tutorials/getusermedia/intro/)
 * [Using the media capture API](https://www.sitepoint.com/using-the-media-capture-api/)
 
-###File
+### File
 
 * [Using files from web applications (MDN)](https://developer.mozilla.org/en-US/docs/Using_files_from_web_applications)
 * [Reading local files in JavaScript](http://www.html5rocks.com/en/tutorials/file/dndfiles/)
 * [File API Draft](https://w3c.github.io/FileAPI/)
 * [File system API](http://www.w3.org/TR/file-system-api/)
 
-###Frame timing
+### Frame timing
 
 * [Video from google developers](https://www.youtube.com/watch?v=4zoC3eaa9z0)
 * [Draft from W3C](https://w3c.github.io/frame-timing/)
 
-###requestIdleCallback
+### requestIdleCallback
 
 * [On Google developers](https://developers.google.com/web/updates/2015/08/using-requestidlecallback)
 
-###requestAnimationFrame
+### requestAnimationFrame
 
 * [Using requestAnimationFrame (CSS Tricks)](https://css-tricks.com/using-requestanimationframe/)
 * [Great article by Paul Irish](https://medium.com/@paul_irish/requestanimationframe-scheduling-for-nerds-9c57f7438ef4#.9gev5fdub)
 
-###Web animations
+### Web animations
 
 * [Intro to web animations](http://danielcwilson.com/blog/2015/07/animations-intro/)
 * [When to Use the Web Animations API](http://danielcwilson.com/blog/2016/08/why-waapi/)
 
-##Semantics
+## Semantics
 
 * [Semantic elements from W3Schools](http://www.w3schools.com/html/html5_semantic_elements.asp)
 * [Sections and Outlines of an HTML5 from MDN Document](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines)
 * [HTML5 Semantics from Smashing Magazine](https://www.smashingmagazine.com/2011/11/html5-semantics/)
 * [Lesser known semantics element from W3C & Opera](https://www.w3.org/wiki/Lesser_-_known_semantic_elements)
 
-##Accessibility
+## Accessibility
 
 * [ARIA from MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA)
 * [Accessibility in HTML5](http://www.clarissapeterson.com/2012/11/html5-accessibility/)
@@ -186,18 +186,18 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * [Aria in HTML](https://www.paciellogroup.com/blog/2014/10/aria-in-html-there-goes-the-neighborhood/)
 * [Accessible and Responsive HTML5 Video Player](https://ind.ie/about/blog/accessible-video-player/)
 
-##DOM Management
+## DOM Management
 
-###Shadow DOM
+### Shadow DOM
 
 * [Shadow DOM v1: self-contained web components](https://developers.google.com/web/fundamentals/primers/shadowdom/)
 * [What's New in Shadow DOM v1 (by examples)](http://hayato.io/2016/shadowdomv1/)
 
-###Data Binding
+### Data Binding
 
 * [Data-binding Revolutions with Object.observe()](http://www.html5rocks.com/en/tutorials/es7/observe/)
 
-###Web Components
+### Web Components
 
 * [Custom elements v1: reusable web components](https://developers.google.com/web/fundamentals/primers/customelements/)
 * [Polymer project](https://github.com/polymer)
@@ -207,11 +207,11 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * [HTML imports](http://www.html5rocks.com/en/tutorials/webcomponents/imports/)
 * [Building Webapps with Yeoman and Polymer](http://www.html5rocks.com/en/tutorials/webcomponents/yeoman/)
 
-##Progressive web apps
+## Progressive web apps
 
 * [The Business Case for Progressive Web Apps](https://cloudfour.com/thinks/the-business-case-for-progressive-web-apps/)
 
-###Service Workers
+### Service Workers
 
 * [The Service Worker Cookbook](https://serviceworke.rs/)
 * [Offline content with service workers](https://madebymike.com.au/writing/service-workers/)
@@ -222,7 +222,7 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * [Service Workers from W3](http://www.w3.org/TR/service-workers/)
 * [ServiceWorker: Revolution of the Web Platform](https://ponyfoo.com/articles/serviceworker-revolution)
 
-###Offline caching
+### Offline caching
 
 * [Instant-loading Offline-first (Progressive Web App Summit 2016)](https://www.youtube.com/watch?v=qDJAz3IIq18)
 * [Offline Storage for Progressive Web Apps (article by Addy Osmani)](https://medium.com/dev-channel/offline-storage-for-progressive-web-apps-70d52695513c#.jsbxgywzz)
@@ -230,14 +230,14 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * [Manifest for web application from W3C (working draft)](https://w3c.github.io/manifest/)
 * [WebApp Manifest in Chrome for Android](http://updates.html5rocks.com/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android)
 
-###Push Notifications
+### Push Notifications
 
 * [Push Notifications On The Web - Google Chrome](http://deanhume.com/Home/BlogPost/push-notifications-on-the-web---google-chrome/10128)
 * [Push Notifications on the Open Web](http://updates.html5rocks.com/2015/03/push-notificatons-on-the-open-web)
 * [Push API W3C draft](http://w3c.github.io/push-api/)
 * [Notifications API](https://notifications.spec.whatwg.org/)
 
-##Client side storage
+## Client side storage
 
 * [Client-Side Storage](http://www.html5rocks.com/en/tutorials/offline/storage/)
 * [Offline Cookbook](https://jakearchibald.com/2014/offline-cookbook/)
@@ -245,7 +245,7 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * [Real-World Off-Line Data Storage](https://code.tutsplus.com/tutorials/real-world-off-line-data-storage--net-34063)
 * [Local storage tutorial](https://developer.mozilla.org/en-US/Add-ons/Overlay_Extensions/XUL_School/Local_Storage)
 
-##Performance
+## Performance
 
 * [Accelerated Mobile Pages (AMP)](https://www.ampproject.org/docs/get_started/about-amp.html)
 * [Google developers best practices](https://developers.google.com/speed/docs/insights/rules)
@@ -272,32 +272,32 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * [HTML5 Network Information API](https://code.tutsplus.com/tutorials/html5-network-information-api--cms-21598)
 * [Sencha Touch tutorials](http://docs.sencha.com)
 
-##Communications and interoperability
+## Communications and interoperability
 
-###Web Sockets
+### Web Sockets
 
 * [Using WebWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers)
 * [Introducing Websockets](http://www.html5rocks.com/en/tutorials/websockets/basics/)
 
-###WebRTC
+### WebRTC
 
 * [What is WebRTC and how does it work](http://www.innoarchitech.com/what-is-webrtc-and-how-does-it-work/)
 * [WebRTC made simple](http://blog.carbonfive.com/2014/10/16/webrtc-made-simple/)
 * [WebRTC data channels tutorial](http://www.html5rocks.com/en/tutorials/webrtc/datachannels/)
 * [WebRTC data channels from MDN](https://developer.mozilla.org/en-US/docs/Games/Techniques/WebRTC_data_channels)
 
-##Web Workers
+## Web Workers
 
 * [Web Worker Basics](http://www.html5rocks.com/en/tutorials/workers/basics/)
 * [How fast are web workers?](https://hacks.mozilla.org/2015/07/how-fast-are-web-workers/)
 * [Web Workers in MDN](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers)
 * [Getting started with Web Workers](https://code.tutsplus.com/tutorials/getting-started-with-web-workers--net-27667)
 
-##WebGL
+## WebGL
 
 * [WebGL Fundamentals](http://www.html5rocks.com/en/tutorials/webgl/webgl_fundamentals/)
 
-##Browser compatibility
+## Browser compatibility
 
 * [I want to use](http://www.iwanttouse.com/)
 * [Can I use...](http://caniuse.com/)
@@ -305,14 +305,14 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * [HTML5 test](http://beta.html5test.com/)
 * [HTML5 demos](http://html5demos.com/)
 
-##Books
+## Books
 
 * [Dive into HTML5](http://diveintohtml5.info/)
 * [HTML5: Up and Running](https://www.amazon.com/HTML5-Up-Running-Mark-Pilgrim/dp/0596806027)
 * [Using the HTML5 Filesystem API](http://shop.oreilly.com/product/0636920021360.do)
 * [HTML5 Game Development Insights](http://www.apress.com/9781430266976)
 
-##Game development
+## Game development
 
 * [Getting started with HTML5 Game Development from Mozilla Hacks](https://hacks.mozilla.org/2013/09/getting-started-with-html5-game-development/)
 * [HTML 5 game development video series by Mozilla](https://hacks.mozilla.org/2016/02/html-5-game-development-video-series/)
@@ -328,16 +328,16 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
   - [Stage.js](https://github.com/shakiba/stage.js)
   - [cocos2d](https://github.com/cocos2d/cocos2d-html5)
 
-##Videos and Keynotes
+## Videos and Keynotes
 
 * [HTML5 Developer Conference](http://html5devconf.com/videos.html)
 * [Polymer: declarative, encapsulated, reusable components](https://www.youtube.com/watch?v=DH1vTVkqCDQ)
 * [Making the mobile web fast, feature-rich, and beautiful](https://www.youtube.com/watch?v=EXjPsvwIDwU)
 * [Dart: HTML of the Future, Today!](https://www.youtube.com/watch?v=euCNWhs7ivQ)
 
-##Websites and resources
+## Websites and resources
 
-###Websites
+### Websites
 
 * [HTML official reference](http://docs.webplatform.org/wiki/html)(allows collaborative modification of content like wiki)
 * [HTML5 Rocks](http://www.html5rocks.com/) (news, tutorials and updates)
@@ -348,14 +348,14 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * [W3C Highlights form June 2014](http://www.w3.org/2014/06/w3c-highlights/)
 * [HTML5 Please](http://html5please.com/) (Know when HTML5 feature are ready to use)
 
-###Weekly news
+### Weekly news
 
 * [HTML5 Weekly](http://html5weekly.com/)
 * [Open Web Platform Daily Digest](https://webplatformdaily.org/)
 * [Mozilla Hacks Weekly Articles](https://hacks.mozilla.org/category/mozilla-hacks-weekly/)
 * [Responsive Design Newsletter](http://responsivedesignweekly.com/)
 
-###Twitter
+### Twitter
 
 * [@html5](https://twitter.com/html5)
 * [@html5rock](https://twitter.com/html5rock)
@@ -371,6 +371,6 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 * [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness)
 * [lists](https://github.com/jnv/lists)
 
-##Contributing
+## Contributing
 
 Your contributions are always welcome!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
