### PR TITLE
restore link to Dive into HTML5

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ A curated list of awesome HTML5 resources. Inspired by [awesome-php](https://git
 
 ## Books
 
+* [Dive Into HTML5](http://diveinto.html5doctor.com/)
 * [HTML5: Up and Running](https://www.amazon.com/HTML5-Running-Dive-Future-Development/dp/0596806027)
 * [Using the HTML5 Filesystem API](http://shop.oreilly.com/product/0636920021360.do)
 * [HTML5 Game Development Insights](https://www.apress.com/us/book/9781430266976)


### PR DESCRIPTION
I found a valid link to Dive into HTML5 which was deleted in c04052a51eaf32aa0d38c9b32bb1443ecb1ad032.
BTW, I didn't know the author of the book has 410ed...
http://meyerweb.com/eric/thoughts/2011/10/04/searching-for-mark-pilgrim/
